### PR TITLE
Update Fastly go-compute SDK to 1.6

### DIFF
--- a/subcalc-api/go.mod
+++ b/subcalc-api/go.mod
@@ -2,6 +2,6 @@ module compute-starter-kit-go
 
 go 1.24.3
 
-require github.com/fastly/compute-sdk-go v1.4.2
+require github.com/fastly/compute-sdk-go v1.6.0
 
 require github.com/csjayp/subcalc/subcalc-go v0.0.0-20250614144219-bc0373e112f9

--- a/subcalc-api/go.sum
+++ b/subcalc-api/go.sum
@@ -1,4 +1,4 @@
 github.com/csjayp/subcalc/subcalc-go v0.0.0-20250614144219-bc0373e112f9 h1:0AcnBiyAsT3GefDnssxdsBgBxrIkb0U5RltoQBLjEkM=
 github.com/csjayp/subcalc/subcalc-go v0.0.0-20250614144219-bc0373e112f9/go.mod h1:OUGR/O1pPRqSbxt7lyY5AztljlEuG7qAkrhMm2KzOSA=
-github.com/fastly/compute-sdk-go v1.4.2 h1:GhPVB+lGzOidSANwNOE/M4z3uX7p4cjTNcV8xKdZdqs=
-github.com/fastly/compute-sdk-go v1.4.2/go.mod h1:D72sqisfs4IX6ckaitUNBc2daWkayIxO/fIZgFRHLT0=
+github.com/fastly/compute-sdk-go v1.6.0 h1:FIqbNle10iL2OXIIdkI0+1hk3vS3vVxSCB9UX5p0U7M=
+github.com/fastly/compute-sdk-go v1.6.0/go.mod h1:Vp0ABRKndMg9gbKntRkXXXxC7uNJgW64eCods/8IEtU=


### PR DESCRIPTION
- A number of bug fixes have gone in since we last updated it